### PR TITLE
Clarify the name with owner field

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ To set this up, you'll need to have an [Azure Portal account](https://portal.azu
 
 | Setting | Value
 | -------- | -------
-| `PullRequestRepository` | URL to the repository that houses your Jekyll site for pull requests to be created against
+| `PullRequestRepository` | `owner/name` of the repository that houses your Jekyll site for pull requests to be created against. For example, `haacked/haacked.com` will post to https://github.com/haacked/haacked.com
 | `GitHubToken` | A [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with access to edit your target repository. 


### PR DESCRIPTION
Makes it clear that you shouldn't put a full Repo URL in this field, but use the name with owner instead.