### PR TITLE
Validate comment site URL

### DIFF
--- a/JekyllBlogCommentsAzure.sln
+++ b/JekyllBlogCommentsAzure.sln
@@ -5,9 +5,13 @@ VisualStudioVersion = 15.0.27520.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JekyllBlogCommentsAzure", "JekyllBlogCommentsAzure\JekyllBlogCommentsAzure.csproj", "{D71CC922-08B2-4C1A-B0D1-4AEF57E54765}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{464BAC08-68A7-40BA-91F0-856239A43789}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Meta", "Meta", "{464BAC08-68A7-40BA-91F0-856239A43789}"
 	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
+		LICENSE = LICENSE
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
+++ b/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
@@ -28,7 +28,7 @@ namespace JekyllBlogCommentsAzure
 
             // Make sure the site posting the comment is the correct site.
             var commentSite = ConfigurationManager.AppSettings["CommentWebsiteUrl"];
-            if (commentSite != null && !AreSameSites(commentSite, form["comment-site"]))
+            if (!String.IsNullOrWhiteSpace(commentSite) && !AreSameSites(commentSite, form["comment-site"]))
                 return request.CreateErrorResponse(HttpStatusCode.BadRequest, "Please make sure you post this to your own Jekyll comments receiever.");
 
             if (TryCreateCommentFromForm(form, out var comment, out var errors))

--- a/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
+++ b/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
@@ -47,10 +47,8 @@ namespace JekyllBlogCommentsAzure
 
         private static bool AreSameSites(string commentSite, string postedCommentSite)
         {
-            Uri commentSiteUri;
-            Uri postedCommentSiteUri;
-            return Uri.TryCreate(commentSite, UriKind.Absolute, out commentSiteUri)
-                && Uri.TryCreate(postedCommentSite, UriKind.Absolute, out postedCommentSiteUri)
+            return Uri.TryCreate(commentSite, UriKind.Absolute, out var commentSiteUri)
+                && Uri.TryCreate(postedCommentSite, UriKind.Absolute, out var postedCommentSiteUri)
                 && commentSiteUri.Host.Equals(postedCommentSiteUri.Host, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ To set this up, you'll need to have an [Azure Portal account](https://portal.azu
 | Setting | Value
 | -------- | -------
 | `PullRequestRepository` | `owner/name` of the repository that houses your Jekyll site for pull requests to be created against. For example, `haacked/haacked.com` will post to https://github.com/haacked/haacked.com
-| `GitHubToken` | A [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with access to edit your target repository. 
+| `GitHubToken` | A [GitHub personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with access to edit your target repository.
+| `CommentWebsiteUrl` | The URL to the website that hosts the comments. This is used to make sure the correct site is posting comments to the receiver.


### PR DESCRIPTION
__NOTE: I haven't done an end-to-end test of the code yet!__ Wanted to get a review in first.

Since people will share jekyll site templates, it'd be very easy for someone to accidentally host a site that posts to someone else's Jekyll receiver. We want to avoid that happening by mistake. It's still possible for someone to post to another receiver, but they'll have to be intentional about it, and it won't really do them any good.

This requires that comment forms add the following field to their template: <input name="comment-site" type="hidden" value="{{ site.url }}">