### PR TITLE
Make ID hex, do not allow date, id or gravatar to be supplied

### DIFF
--- a/JekyllBlogCommentsAzure/JekyllBlogCommentsAzure.csproj
+++ b/JekyllBlogCommentsAzure/JekyllBlogCommentsAzure.csproj
@@ -3,6 +3,9 @@
     <TargetFramework>net461</TargetFramework>
     <Authors>Damien Guard</Authors>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>IDE1006;1701;1702;1705</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.13" />
     <PackageReference Include="Octokit" Version="0.29.0" />

--- a/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
+++ b/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
@@ -118,22 +118,23 @@ namespace JekyllBlogCommentsAzure
         /// </summary>
         private class Comment
         {
-            public Comment(string post_id, string message, string name, string email, DateTime? date = null, Uri url = null, int? id = null, string gravatar = null)
+            public Comment(string post_id, string message, string name, string email, Uri url = null)
             {
                 this.post_id = validPathChars.Replace(post_id, "-");
                 this.message = message;
                 this.name = name;
                 this.email = email;
-                this.date = date ?? DateTime.UtcNow;
                 this.url = url;
-                this.id = id ?? new { this.post_id, this.name, this.message, this.date }.GetHashCode();
-                this.gravatar = gravatar ?? EncodeGravatar(email);
+
+                date = DateTime.UtcNow;
+                id = new {this.post_id, this.name, this.message, this.date}.GetHashCode().ToString("x8");
+                gravatar = EncodeGravatar(email);
             }
 
             [YamlIgnore]
             public string post_id { get; }
 
-            public int id { get; }
+            public string id { get; }
             public DateTime date { get; }
             public string name { get; }
             public string email { get; }


### PR DESCRIPTION
- ID is now a string and we calculate as before but in hex to avoid negative numbers
- Date is no longer able to be supplied by form - always now
- Gravatar no longer able to be supplied by form - always MD5 hash of email
- ID no longer able to be supplied by form - always GetHashCode/hex