### PR TITLE
Add support for any avatar

### DIFF
--- a/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
+++ b/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
@@ -118,7 +118,7 @@ namespace JekyllBlogCommentsAzure
         /// </summary>
         private class Comment
         {
-            public Comment(string post_id, string message, string name, string email, Uri url = null)
+            public Comment(string post_id, string message, string name, string email = null, Uri url = null, string avatar = null)
             {
                 this.post_id = validPathChars.Replace(post_id, "-");
                 this.message = message;
@@ -128,7 +128,8 @@ namespace JekyllBlogCommentsAzure
 
                 date = DateTime.UtcNow;
                 id = new {this.post_id, this.name, this.message, this.date}.GetHashCode().ToString("x8");
-                gravatar = EncodeGravatar(email);
+                if (Uri.TryCreate(avatar, UriKind.Absolute, out Uri avatarUrl))
+                    this.avatar = avatarUrl;
             }
 
             [YamlIgnore]
@@ -138,18 +139,14 @@ namespace JekyllBlogCommentsAzure
             public DateTime date { get; }
             public string name { get; }
             public string email { get; }
-            public string gravatar { get; }
+
+            [YamlMember(typeof(string))]
+            public Uri avatar { get; }
 
             [YamlMember(typeof(string))]
             public Uri url { get; }
 
             public string message { get; }
-
-            static string EncodeGravatar(string email)
-            {
-                using (var md5 = System.Security.Cryptography.MD5.Create())
-                    return BitConverter.ToString(md5.ComputeHash(System.Text.Encoding.UTF8.GetBytes(email))).Replace("-", "").ToLower();
-            }
         }
     }
 }

--- a/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
+++ b/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
@@ -76,7 +76,7 @@ namespace JekyllBlogCommentsAzure
             // Create a pull request for the new branch and file
             return await github.Repository.PullRequest.Create(repo.Id, new NewPullRequest(fileRequest.Message, newBranch.Ref, defaultBranch.Name)
             {
-                Body = comment.message
+                Body = $"avatar: <img src=\"{comment.avatar}\" width=\"64\" height=\"64\" />\n\n{comment.message}"
             });
         }
 

--- a/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
+++ b/JekyllBlogCommentsAzure/PostCommentToPullRequestFunction.cs
@@ -69,7 +69,7 @@ namespace JekyllBlogCommentsAzure
             // Create a new file with the comments in it
             var fileRequest = new CreateFileRequest($"Comment by {comment.name} on {comment.post_id}", new SerializerBuilder().Build().Serialize(comment), newBranch.Ref)
             {
-                Committer = new Committer(comment.name, comment.email, comment.date)
+                Committer = new Committer(comment.name, comment.email ?? ConfigurationManager.AppSettings["CommentFallbackCommitEmail"] ?? "redacted@example.com", comment.date)
             };
             await github.Repository.Content.CreateFile(repo.Id, $"_data/comments/{comment.post_id}/{comment.id}.yml", fileRequest);
 


### PR DESCRIPTION
This PR makes the system more flexible and generic when it comes to avatars by becoming avatar agnostic. It's up to the client to calculate and send the avatar URL to the server. The server just writes whatever is provided to the Yaml.

In doing so, this PR renders the avatar in the PR body so that the moderator can see what avatar was submitted by the client.

![example](https://user-images.githubusercontent.com/19977/41248495-179b0fe4-6d66-11e8-8f76-f30dbc14c07a.png)

If a comment system wants to support gravatar, it needs to calculate the gravatar URL on the client. I have some example code for this I'll share later.
